### PR TITLE
add missing include of libparse.sh

### DIFF
--- a/src/lib/libpretty.sh
+++ b/src/lib/libpretty.sh
@@ -22,6 +22,7 @@
 include color
 include common
 include cla
+include parse
 
 
 ## Code


### PR DESCRIPTION
This is required for the read-0 function.